### PR TITLE
fix: added missing body parsers for JSON and URL-encoded requests

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -15,6 +15,8 @@ const server = http.createServer(app);
 const PORT = 3000 ;
 
 app.use(cookieParser()); 
+app.use(express.json())
+app.use(express.urlencoded())  
 
 app.use("/",authRoutes);
 app.use("/", userRoutes);


### PR DESCRIPTION
Body parser was missing without this req.body was undefined 