### PR TITLE
feat: added models tag crud funcs and filter by tag / category

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -22,3 +22,39 @@ model User {
   password String
 
 }
+
+enum Category {
+  GRAMMAR
+  VOCABULARY
+  SPEAKING
+  LISTENING
+  WRITING
+}
+
+model Course {
+  id          Int      @id @default(autoincrement())
+  title       String
+  description String?
+  lessons     Lesson[]
+}
+
+model Lesson {
+  id            Int            @id @default(autoincrement())
+  title         String
+  content       String?
+  course        Course         @relation(fields: [courseId], references: [id])
+  courseId      Int
+  contributions Contribution[]
+}
+
+model Contribution {
+  id         Int       @id @default(autoincrement())
+  title      String
+  content    String
+  category   Category
+  tags       String[]
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @updatedAt
+  lesson     Lesson    @relation(fields: [lessonId], references: [id])
+  lessonId   Int
+}

--- a/api/src/services/contribution.service.ts
+++ b/api/src/services/contribution.service.ts
@@ -1,0 +1,105 @@
+import prisma from "./prisma";
+
+enum Category {
+  GRAMMAR = "GRAMMAR",
+  VOCABULARY = "VOCABULARY",
+  SPEAKING = "SPEAKING",
+  LISTENING = "LISTENING",
+  WRITING = "WRITING",
+}
+
+export const contributionService = {
+  //Contribution
+  async createContribution(data: {
+    title: string;
+    content: string;
+    category: Category;
+    tags?: string[];
+    lessonId: number;
+  }) {
+    return prisma.contribution.create({ data });
+  },
+
+  async getContribution(id: number) {
+    return prisma.contribution.findUnique({
+      where: { id },
+    });
+  },
+
+  async updateContribution(id: number, data: {
+    title?: string;
+    content?: string;
+    category?: Category;
+    tags?: string[];
+  }) {
+    return prisma.contribution.update({
+      where: { id },
+      data,
+    });
+  },
+
+  async deleteContribution(id: number) {
+    return prisma.contribution.delete({
+      where: { id },
+    });
+  },
+
+  //Tags
+  async addTag(id: string, tag: string) {
+    return prisma.contribution.update({
+      where: { id },
+      data: { tags: { push: tag } },
+    });
+  },
+
+  async removeTag(id: string, tag: string) {
+    const contribution = await prisma.contribution.findUnique({
+      where: { id },
+    });
+    if (!contribution) return null;
+    const updatedTags = contribution.tags.filter((t: string) => t !== tag);
+    return prisma.contribution.update({
+      where: { id },
+      data: { tags: updatedTags },
+    });
+  },
+
+  async updateTag(id: string, oldTag: string, newTag: string) {
+    const contribution = await prisma.contribution.findUnique({
+      where: { id },
+    });
+    if (!contribution) return null;
+    const updatedTags = contribution.tags.map((t: string) =>
+      t === oldTag ? newTag : t
+    );
+    return prisma.contribution.update({
+      where: { id },
+      data: { tags: updatedTags },
+    });
+  },
+
+  async getTags(id: string) {
+    const contribution = await prisma.contribution.findUnique({
+      where: { id },
+    });
+    return contribution?.tags || [];
+  },
+
+  async filterByTag(tag: string) {
+    return prisma.contribution.findMany({
+      where: {
+        tags: {
+          has: tag,
+        },
+      },
+    });
+  },
+
+  //Category
+  async filterByCategory(category: Category) {
+    return prisma.contribution.findMany({
+      where: { category },
+    });
+  },
+};
+


### PR DESCRIPTION
in response to issue #16 
1. added simple course / lesson model for now to show references 
2. added contribution model with tags and category as fields
3. defined category as enum
4. added crud funcs for tags and contributions
5. added filter by tag / category functions